### PR TITLE
Retrieve claims about a META-ID from META Claims Index

### DIFF
--- a/app/core/services/meta-id.js
+++ b/app/core/services/meta-id.js
@@ -92,3 +92,47 @@ export const createClaim = variables =>
 `,
     variables
   )
+
+/**
+ * Read all verifiable claims from the META Claims Index by `issuer`
+ *
+ * @param  {Object} variables        [description]
+ * @param  {String} variables.issuer [description]
+ * @return {Object}                  Response data
+ */
+export const readClaimsByIssuer = variables =>
+  metaNetworkRequest(
+    `
+  query readClaimsByIssuer($issuer: String) {
+    claim (issuer: $issuer) {
+      id
+      issuer
+      subject
+      claim
+    }
+  }
+`,
+    variables
+  )
+
+/**
+ * Read all verifiable claims from the META Claims Index by `subject`
+ *
+ * @param  {Object} variables         [description]
+ * @param  {String} variables.subject [description]
+ * @return {Object}                   Response data
+ */
+export const readClaimsBySubject = variables =>
+  metaNetworkRequest(
+    `
+  query readClaimsBySubject($subject: String) {
+    claim (subject: $subject) {
+      id
+      issuer
+      subject
+      claim
+    }
+  }
+`,
+    variables
+  )

--- a/app/domains/claims/actionTypes.js
+++ b/app/domains/claims/actionTypes.js
@@ -1,3 +1,4 @@
 import { name } from './constants'
 
 export const CREATE_CLAIM = `${name}/CREATE_CLAIM`
+export const READ_CLAIMS = `${name}/READ_CLAIMS`

--- a/app/domains/claims/actions.js
+++ b/app/domains/claims/actions.js
@@ -15,3 +15,25 @@ export const createClaim = claim => ({
   type: actions.CREATE_CLAIM,
   promise: MetaId.createClaim(claim),
 })
+
+/**
+ * Read verifiable claims from the META Claims Index by `issuer`
+ *
+ * @param  {String} issuer Ethereum address of claim issuer
+ * @return {Object}        Flux Standard Action
+ */
+export const readClaimsByIssuer = issuer => ({
+  type: actions.READ_CLAIMS,
+  promise: MetaId.readClaimsByIssuer({ issuer }),
+})
+
+/**
+ * Read verifiable claims from the META Claims Index by `subject`
+ *
+ * @param  {String} subject Ethereum address of claim subject
+ * @return {Object}         Flux Standard Action
+ */
+export const readClaimsBySubject = subject => ({
+  type: actions.READ_CLAIMS,
+  promise: MetaId.readClaimsBySubject({ subject }),
+})

--- a/app/domains/claims/reducer.js
+++ b/app/domains/claims/reducer.js
@@ -17,4 +17,12 @@ export default createReducer(initialState, {
           [action.payload.id]: createClaim(action.payload),
         }),
     }),
+
+  [actions.READ_CLAIMS]: (state, action) =>
+    handle(state, action, {
+      success: prevState =>
+        prevState.merge({
+          [action.payload.id]: createClaim(action.payload),
+        }),
+    }),
 })

--- a/app/domains/claims/selectors.js
+++ b/app/domains/claims/selectors.js
@@ -1,13 +1,41 @@
+import { createSelector } from 'reselect'
+
 import { name } from './constants'
+import { seletors as Identity } from 'domains/identity'
 
 /**
  * Select the entire domain from the store by `name`
- * 
+ *
  * @param  {Object} state Redux store
  * @return {Object}       Domain state
  */
 const getAll = state => state.get(name)
 
-export default {
+/**
+ * Get all claims where META-ID is the `subject`
+ *
+ * @return {Array}
+ */
+const getClaimsAboutIdentity = createSelector(
+  [getAll, Identity.getIdentityById],
+  (claims, identity) => {
+    return identity.claimsReceived.map(claim => claims[claim])
+  }
+)
 
+/**
+ * Get all claims where META-ID is the `issuer`
+ *
+ * @type {Array}
+ */
+const getClaimsByIdentity = createSelector(
+  [getAll, Identity.getIdentityById],
+  (claims, identity) => {
+    return identity.claimsIssued.map(claim => claims[claim])
+  }
+)
+
+export default {
+  claimsAboutIdentity: getClaimsAboutIdentity,
+  claimsByIdentity: getClaimsByIdentity,
 }


### PR DESCRIPTION
- Add claim by issuer GraphQL query to the meta-id service
- Add claim by subject GraphQL query to the meta-id service
- Add readClaimsByIssuer action to claims domain (actions/reducer)
- Add readClaimsBySubject action to claims domain (actions/reducer)
- Add getClaimsAboutIdentity selector to claims domain
- Add getClaimsByIdentity selector to claims domain