### PR TITLE
Read profile claims

### DIFF
--- a/app/domains/claims/actions.js
+++ b/app/domains/claims/actions.js
@@ -39,6 +39,17 @@ export const readClaimsBySubject = subject => ({
 })
 
 /**
+ * Read verifiable claims from the META Claims Index by `subject` AND `property`
+ *
+ * @param  {String} subject Ethereum address of claim subject
+ * @return {Object}         Flux Standard Action
+ */
+export const readClaimsBySubjectAndProperty = (property, subject) => ({
+  type: actions.READ_CLAIMS,
+  promise: MetaId.readClaims({ filter: { property, subject } }),
+})
+
+/**
  * Verify a META Claim with a META Claims Service
  *
  * @param  {Object} claim    Valid META Claim object


### PR DESCRIPTION
Closes #55 

- Added `readClaimsBySubjectAndProperty` action to `claims` domain to allow specific profile claims about a subject to be fetched - eg. `readClaimsBySubjectAndProperty('profile.name', 0x123...)`
- Tested retrieval of profile claim from META Claims index and retrieval of claim data from Swarm (no code added)
- Usage of claim retrieval methods and claim data will be added in separate issues as needed by views
