### PR TITLE
Add custom primitives

### DIFF
--- a/app/core/primitives/Anchor/Anchor.js
+++ b/app/core/primitives/Anchor/Anchor.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+/**
+ * @namespace StyledAnchor
+ * @desc styled-component 💅
+ * @return {Function} React component
+ */
+const StyledAnchor = styled('a')`
+  color: ${({ color, theme }) => theme[color] || color};
+  cursor: ${({ cursor }) => cursor};
+`
+
+/**
+ * @namespace Box
+ * @desc Primitive component
+ * @param {Object} props - Component props
+ * @param {Object} props.children - Child components
+ * @return {Function} React component
+ */
+const Anchor = ({ children, ...props }) => (
+  <StyledAnchor {...props}>{children}</StyledAnchor>
+)
+
+/**
+ * @name defaultProps
+ * @memberof Anchor
+ * @desc Primitive's default properties
+ */
+Anchor.defaultProps = {
+  color: 'inherit',
+  cursor: 'pointer',
+}
+
+/**
+ * @name propTypes
+ * @memberof Anchor
+ * @desc Primitive's prop type definitions
+ */
+Anchor.propTypes = {
+  /** Color */
+  color: PropTypes.string,
+  /** Cursor */
+  cursor: PropTypes.string,
+}
+
+export default Anchor

--- a/app/core/primitives/Anchor/index.js
+++ b/app/core/primitives/Anchor/index.js
@@ -1,0 +1,3 @@
+import Anchor from './Anchor'
+
+export default Anchor

--- a/app/core/primitives/BodyLink/BodyLink.js
+++ b/app/core/primitives/BodyLink/BodyLink.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { Text } from 'jaak-primitives'
+
+/**
+ * @namespace StyledBodyLink
+ * @desc styled-component 💅
+ * @return {Function} React component
+ */
+const StyledBodyLink = styled(Text)`
+  color: ${({ color, theme }) => theme[color]};
+  cursor: ${({ cursor }) => cursor};
+`
+
+/**
+ * @namespace Box
+ * @desc Primitive component
+ * @param {Object} props - Component props
+ * @param {Object} props.children - Child components
+ * @return {Function} React component
+ */
+const BodyLink = ({ children, ...props }) => (
+  <StyledBodyLink {...props}>{children}</StyledBodyLink>
+)
+
+/**
+ * @name defaultProps
+ * @memberof BodyLink
+ * @desc Primitive's default properties
+ */
+BodyLink.defaultProps = {
+  activePropName: 'active',
+  color: 'accent',
+  cursor: 'pointer',
+}
+
+/**
+ * @name propTypes
+ * @memberof BodyLink
+ * @desc Primitive's prop type definitions
+ */
+BodyLink.propTypes = {
+  /** Name of prop to inject when Link is active */
+  activePropName: PropTypes.string,
+  /** Color */
+  color: PropTypes.string,
+  /** Cursor */
+  cursor: PropTypes.string,
+}
+
+export default BodyLink

--- a/app/core/primitives/BodyLink/BodyLink.js
+++ b/app/core/primitives/BodyLink/BodyLink.js
@@ -1,17 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Text } from 'jaak-primitives'
+
+import Anchor from '../Anchor'
 
 /**
  * @namespace StyledBodyLink
  * @desc styled-component 💅
  * @return {Function} React component
  */
-const StyledBodyLink = styled(Text)`
-  color: ${({ color, theme }) => theme[color]};
-  cursor: ${({ cursor }) => cursor};
-`
+const StyledBodyLink = styled(Anchor)``
 
 /**
  * @namespace Box
@@ -32,7 +30,6 @@ const BodyLink = ({ children, ...props }) => (
 BodyLink.defaultProps = {
   activePropName: 'active',
   color: 'accent',
-  cursor: 'pointer',
 }
 
 /**
@@ -45,8 +42,6 @@ BodyLink.propTypes = {
   activePropName: PropTypes.string,
   /** Color */
   color: PropTypes.string,
-  /** Cursor */
-  cursor: PropTypes.string,
 }
 
 export default BodyLink

--- a/app/core/primitives/BodyLink/index.js
+++ b/app/core/primitives/BodyLink/index.js
@@ -1,0 +1,3 @@
+import BodyLink from './BodyLink'
+
+export default BodyLink

--- a/app/core/primitives/Button/Button.js
+++ b/app/core/primitives/Button/Button.js
@@ -11,12 +11,11 @@ import { Button as ButtonPrimitive } from 'jaak-primitives'
 const StyledButton = styled(ButtonPrimitive)`
   background-color: ${({ backgroundColor, theme }) =>
     theme[backgroundColor] || backgroundColor};
-  box-shadow: ${({ boxShadow }) => boxShadow};
   display: ${({ display }) => display};
 `
 
 /**
- * @namespace Box
+ * @namespace Button
  * @desc Primitive component
  * @param {Object} props - Component props
  * @param {Object} props.children - Child components
@@ -33,7 +32,6 @@ const Button = ({ children, ...props }) => (
  */
 Button.defaultProps = {
   backgroundColor: 'none',
-  boxShadow: 'none',
   display: 'block',
 }
 
@@ -45,8 +43,6 @@ Button.defaultProps = {
 Button.propTypes = {
   /** Background colour */
   backgroundColor: PropTypes.string,
-  /** Box shadow */
-  boxShadow: PropTypes.string,
   /** Display */
   display: PropTypes.string,
 }

--- a/app/core/primitives/FileInputLabel/FileInputLabel.js
+++ b/app/core/primitives/FileInputLabel/FileInputLabel.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+import Label from '../Label'
+
+/**
+ * @namespace StyledFileInputLabel
+ * @desc styled-component 💅
+ * @return {Function} React component
+ */
+const StyledFileInputLabel = styled(Label)`
+  border-bottom-left-radius: ${({ borderRadius, borderBottomLeftRadius }) =>
+    borderBottomLeftRadius || borderRadius};
+  border-bottom-right-radius: ${({ borderRadius, borderBottomRightRadius }) =>
+    borderBottomRightRadius || borderRadius};
+  border-top-left-radius: ${({ borderRadius, borderTopLeftRadius }) =>
+    borderTopLeftRadius || borderRadius};
+  border-top-right-radius: ${({ borderRadius, borderTopRightRadius }) =>
+    borderTopRightRadius || borderRadius};
+`
+
+/**
+ * @namespace FileInputLabel
+ * @desc Primitive component
+ * @param {Object} props - Component props
+ * @param {Object} props.children - Child components
+ * @return {Function} React component
+ */
+const FileInputLabel = ({ children, ...props }) => (
+  <StyledFileInputLabel {...props}>{children}</StyledFileInputLabel>
+)
+
+/**
+ * @name defaultProps
+ * @memberof FileInputLabel
+ * @desc Primitive's default properties
+ */
+FileInputLabel.defaultProps = {
+  backgroundColor: 'accent',
+  borderRadius: '4px',
+  borderRadiusBottomLeft: null,
+  borderRadiusBottomRight: null,
+  borderRadiusTopLeft: null,
+  borderRadiusTopRight: null,
+  color: 'white',
+  fontWeight: 700,
+  padding: ['12px', '24px'],
+}
+
+/**
+ * @name propTypes
+ * @memberof FileInputLabel
+ * @desc Primitive's prop type definitions
+ */
+FileInputLabel.propTypes = {
+  /** Border bottom left radius */
+  borderBottomLeftRadius: PropTypes.string,
+  /** Border bottom right radius */
+  borderBottomRightRadius: PropTypes.string,
+  /** Border top left radius */
+  borderTopLeftRadius: PropTypes.string,
+  /** Border top right radius */
+  borderTopRightRadius: PropTypes.string,
+}
+
+export default FileInputLabel

--- a/app/core/primitives/FileInputLabel/index.js
+++ b/app/core/primitives/FileInputLabel/index.js
@@ -1,0 +1,3 @@
+import FileInputLabel from './FileInputLabel'
+
+export default FileInputLabel

--- a/app/core/primitives/HeaderLink/HeaderLink.js
+++ b/app/core/primitives/HeaderLink/HeaderLink.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { Text } from 'jaak-primitives'
+
+/**
+ * @namespace StyledHeaderLink
+ * @desc styled-component 💅
+ * @return {Function} React component
+ */
+const StyledHeaderLink = styled(Text)`
+  color: ${({ color, theme }) => theme[color]};
+  cursor: ${({ cursor }) => cursor};
+
+  ${({ active, theme }) =>
+    active &&
+    `
+    color: ${theme.accent};
+    text-decoration: underline;
+  `} &:hover, &:focus {
+    color: ${({ theme }) => theme.accent};
+  }
+`
+
+/**
+ * @namespace Box
+ * @desc Primitive component
+ * @param {Object} props - Component props
+ * @param {Object} props.children - Child components
+ * @return {Function} React component
+ */
+const HeaderLink = ({ children, ...props }) => (
+  <StyledHeaderLink {...props}>{children}</StyledHeaderLink>
+)
+
+/**
+ * @name defaultProps
+ * @memberof HeaderLink
+ * @desc Primitive's default properties
+ */
+HeaderLink.defaultProps = {
+  activePropName: 'active',
+  color: 'white',
+  cursor: 'pointer',
+}
+
+/**
+ * @name propTypes
+ * @memberof HeaderLink
+ * @desc Primitive's prop type definitions
+ */
+HeaderLink.propTypes = {
+  /** Name of prop to inject when Link is active */
+  activePropName: PropTypes.string,
+  /** Color */
+  color: PropTypes.string,
+  /** Cursor */
+  cursor: PropTypes.string,
+}
+
+export default HeaderLink

--- a/app/core/primitives/HeaderLink/HeaderLink.js
+++ b/app/core/primitives/HeaderLink/HeaderLink.js
@@ -1,17 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Text } from 'jaak-primitives'
+
+import Anchor from '../Anchor'
 
 /**
  * @namespace StyledHeaderLink
  * @desc styled-component 💅
  * @return {Function} React component
  */
-const StyledHeaderLink = styled(Text)`
-  color: ${({ color, theme }) => theme[color]};
-  cursor: ${({ cursor }) => cursor};
-
+const StyledHeaderLink = styled(Anchor)`
   ${({ active, theme }) =>
     active &&
     `

--- a/app/core/primitives/HeaderLink/index.js
+++ b/app/core/primitives/HeaderLink/index.js
@@ -1,0 +1,3 @@
+import HeaderLink from './HeaderLink'
+
+export default HeaderLink

--- a/app/core/primitives/Input/Input.js
+++ b/app/core/primitives/Input/Input.js
@@ -9,8 +9,9 @@ import { Input as InputPrimitive } from 'jaak-primitives'
  * @return {Function} React component
  */
 const StyledInput = styled(InputPrimitive)`
-  border-color: ${({ borderColor, theme }) => theme[borderColor]};
-  color: ${({ color, theme }) => theme[color]};
+  border-color: ${({ borderColor, theme }) =>
+    theme[borderColor] || borderColor};
+  color: ${({ color, theme }) => theme[color] || color};
 `
 
 /**

--- a/app/core/primitives/Label/Label.js
+++ b/app/core/primitives/Label/Label.js
@@ -16,14 +16,14 @@ const StyledLabel = styled(LabelPrimitive)`
   background-color: ${({ backgroundColor, theme }) =>
     theme[backgroundColor] || backgroundColor};
   border-radius: ${({ borderRadius }) => borderRadius};
-  box-shadow: ${({ boxShadow }) => boxShadow};
-  color: ${({ color }) => color};
+  color: ${({ color, theme }) => theme[color] || color};
   cursor: ${({ cursor }) => cursor};
   display: ${({ display }) => display};
+  font-weight: ${({ fontWeight }) => fontWeight};
 `
 
 /**
- * @namespace Box
+ * @namespace Label
  * @desc Primitive component
  * @param {Object} props - Component props
  * @param {Object} props.children - Child components
@@ -39,14 +39,14 @@ const Label = ({ children, ...props }) => (
  * @desc Primitive's default properties
  */
 Label.defaultProps = {
-  backgroundColor: 'primary',
-  borderRadius: '20px',
-  boxShadow: 'none',
-  color: 'white',
+  backgroundColor: 'none',
+  borderRadius: '0px',
+  color: 'inherit',
   cursor: 'pointer',
   display: 'inline-block',
+  fontWeight: 300,
   margin: ['0'],
-  padding: ['8px', '16px'],
+  padding: ['0'],
   size: ['auto'],
 }
 
@@ -60,14 +60,14 @@ Label.propTypes = {
   backgroundColor: PropTypes.string,
   /** Border radius */
   borderRadius: PropTypes.string,
-  /** Box shadow */
-  boxShadow: PropTypes.string,
   /** Colour */
   color: PropTypes.string,
   /** Cursor */
   cursor: PropTypes.string,
   /** Display */
   display: PropTypes.string,
+  /** Font weight */
+  fontWeight: PropTypes.number,
   /** [Margin shorthand](https://polished.js.org/docs/#margin) */
   margin: PropTypes.array,
   /** [Padding shorthand](https://polished.js.org/docs/#padding) */

--- a/app/core/primitives/PrimaryButton/PrimaryButton.js
+++ b/app/core/primitives/PrimaryButton/PrimaryButton.js
@@ -11,7 +11,7 @@ import { Button } from 'jaak-primitives'
 const StyledPrimaryButton = styled(Button)`
   background-color: ${({ backgroundColor, theme }) =>
     theme[backgroundColor] || backgroundColor};
-  color: ${({ color, theme }) => theme[color]};
+  color: ${({ color, theme }) => theme[color] || color};
   display: ${({ display }) => display};
   font-weight: ${({ fontWeight }) => fontWeight};
 `

--- a/app/core/primitives/PrimaryButton/PrimaryButton.js
+++ b/app/core/primitives/PrimaryButton/PrimaryButton.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { Button } from 'jaak-primitives'
+
+/**
+ * @namespace StyledPrimaryButton
+ * @desc styled-component 💅
+ * @return {Function} React component
+ */
+const StyledPrimaryButton = styled(Button)`
+  background-color: ${({ backgroundColor, theme }) =>
+    theme[backgroundColor] || backgroundColor};
+  color: ${({ color, theme }) => theme[color]};
+  display: ${({ display }) => display};
+  font-weight: ${({ fontWeight }) => fontWeight};
+`
+
+/**
+ * @namespace PrimaryButton
+ * @desc Primitive component
+ * @param {Object} props - Component props
+ * @param {Object} props.children - Child components
+ * @return {Function} React component
+ */
+const PrimaryButton = ({ children, ...props }) => (
+  <StyledPrimaryButton {...props}>{children}</StyledPrimaryButton>
+)
+
+/**
+ * @name defaultProps
+ * @memberof PrimaryButton
+ * @desc Primitive's default properties
+ */
+PrimaryButton.defaultProps = {
+  backgroundColor: 'accent',
+  borderRadius: '4px',
+  borderWidth: '0px',
+  color: 'white',
+  display: 'block',
+  fontWeight: 700,
+  padding: ['12px', '24px'],
+}
+
+/**
+ * @name propTypes
+ * @memberof PrimaryButton
+ * @desc Primitive's prop type definitions
+ */
+PrimaryButton.propTypes = {
+  /** Display */
+  display: PropTypes.string,
+  /** Font weight */
+  fontWeight: PropTypes.number,
+}
+
+export default PrimaryButton

--- a/app/core/primitives/PrimaryButton/index.js
+++ b/app/core/primitives/PrimaryButton/index.js
@@ -1,0 +1,3 @@
+import PrimaryButton from './PrimaryButton'
+
+export default PrimaryButton

--- a/app/core/primitives/TextInput/TextInput.js
+++ b/app/core/primitives/TextInput/TextInput.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { Input } from 'jaak-primitives'
+
+/**
+ * @namespace StyledTextInput
+ * @desc styled-component 💅
+ * @return {Function} React component
+ */
+const StyledTextInput = styled(Input)`
+  border-color: ${({ borderColor, theme }) =>
+    theme[borderColor] || borderColor};
+  color: ${({ color, theme }) => theme[color] || color};
+  font-family: ${({ fontFamily }) => fontFamily};
+  text-align: ${({ textAlign }) => textAlign};
+`
+
+/**
+ * @namespace TextInput
+ * @desc Primitive component
+ * @param {Object} props - Component props
+ * @param {Object} props.children - Child components
+ * @return {Function} React component
+ */
+const TextInput = ({ children, ...props }) => (
+  <StyledTextInput {...props}>{children}</StyledTextInput>
+)
+
+/**
+ * @name defaultProps
+ * @memberof TextInput
+ * @desc Primitive's default properties
+ */
+TextInput.defaultProps = {
+  borderColor: 'grey',
+  borderRadius: '4px',
+  color: 'primary',
+  fontFamily: 'inherit',
+  fontWeight: 700,
+  padding: ['12px', '16px'],
+  textAlign: 'left',
+}
+
+/**
+ * @name propTypes
+ * @memberof TextInput
+ * @desc Primitive's prop type definitions
+ */
+TextInput.propTypes = {
+  /** Border colour */
+  borderColor: PropTypes.string,
+  /** Color */
+  color: PropTypes.string,
+  /** Font family */
+  fontFamily: PropTypes.string,
+  /** Text align */
+  textAlign: PropTypes.string,
+}
+
+export default TextInput

--- a/app/core/primitives/TextInput/index.js
+++ b/app/core/primitives/TextInput/index.js
@@ -1,0 +1,3 @@
+import TextInput from './TextInput'
+
+export default TextInput

--- a/app/core/primitives/index.js
+++ b/app/core/primitives/index.js
@@ -12,6 +12,7 @@ import Loader from './Loader'
 import Main from './Main'
 import PrimaryButton from './PrimaryButton'
 import Text from './Text'
+import TextInput from './TextInput'
 import View from './View'
 
 export {
@@ -29,5 +30,6 @@ export {
   Main,
   PrimaryButton,
   Text,
+  TextInput,
   View,
 }

--- a/app/core/primitives/index.js
+++ b/app/core/primitives/index.js
@@ -5,6 +5,7 @@ import Footer from './Footer'
 import Header from './Header'
 import BodyLink from './BodyLink'
 import HeaderLink from './HeaderLink'
+import FileInputLabel from './FileInputLabel'
 import Image from './Image'
 import Input from './Input'
 import Label from './Label'
@@ -23,6 +24,7 @@ export {
   Footer,
   Header,
   HeaderLink,
+  FileInputLabel,
   Image,
   Input,
   Label,

--- a/app/core/primitives/index.js
+++ b/app/core/primitives/index.js
@@ -1,3 +1,4 @@
+import Anchor from './Anchor'
 import Button from './Button'
 import Card from './Card'
 import Error from './Error'
@@ -17,6 +18,7 @@ import TextInput from './TextInput'
 import View from './View'
 
 export {
+  Anchor,
   BodyLink,
   Button,
   Card,

--- a/app/core/primitives/index.js
+++ b/app/core/primitives/index.js
@@ -10,6 +10,7 @@ import Input from './Input'
 import Label from './Label'
 import Loader from './Loader'
 import Main from './Main'
+import PrimaryButton from './PrimaryButton'
 import Text from './Text'
 import View from './View'
 
@@ -26,6 +27,7 @@ export {
   Label,
   Loader,
   Main,
+  PrimaryButton,
   Text,
   View,
 }

--- a/app/core/primitives/index.js
+++ b/app/core/primitives/index.js
@@ -3,6 +3,7 @@ import Card from './Card'
 import Error from './Error'
 import Footer from './Footer'
 import Header from './Header'
+import HeaderLink from './HeaderLink'
 import Image from './Image'
 import Input from './Input'
 import Label from './Label'
@@ -17,6 +18,7 @@ export {
   Error,
   Footer,
   Header,
+  HeaderLink,
   Image,
   Input,
   Label,

--- a/app/core/primitives/index.js
+++ b/app/core/primitives/index.js
@@ -3,6 +3,7 @@ import Card from './Card'
 import Error from './Error'
 import Footer from './Footer'
 import Header from './Header'
+import BodyLink from './BodyLink'
 import HeaderLink from './HeaderLink'
 import Image from './Image'
 import Input from './Input'
@@ -13,6 +14,7 @@ import Text from './Text'
 import View from './View'
 
 export {
+  BodyLink,
   Button,
   Card,
   Error,

--- a/app/core/style/theme.js
+++ b/app/core/style/theme.js
@@ -13,6 +13,7 @@ const customTheme = {
   accent: '#EF3581',
   primary: '#251E2F',
   jaak: '#F08F74',
+  grey: '#979797',
 }
 
 export default customTheme


### PR DESCRIPTION
Closes #60

These primitives extend the base JAAK and application primitives. They are designed to add standard application styles to the base primitives to reduce repetition inside components where the base primitives would otherwise have to be decorated multiple times with the same style props.

Some of the extended application primitives have been updated to only include the base styles (ie. no custom/superficial styles). These can eventually be replaced when the JAAK primitives are updated to include additional base attributes and standard signatures for theme-based attributes.
