### PR TITLE
Add profile domain

### DIFF
--- a/app/core/constants/index.js
+++ b/app/core/constants/index.js
@@ -15,4 +15,6 @@ export const CREDENTIALS = NODE_ENV === 'production' ? 'include' : null
 
 export const META_ID_USERNAME_SUFFIX = 'id.meta'
 
+export const PROFILE_CLAIM_PREFIX = 'profile'
+
 export const STATE_KEY = '@MetaId:store'

--- a/app/core/middleware/claims.js
+++ b/app/core/middleware/claims.js
@@ -7,6 +7,7 @@ import {
   isDomainAction,
 } from 'core/util'
 import { actionTypes as claims } from 'domains/claims'
+import { actions as profile } from 'domains/profile'
 
 const ClaimsMiddleware = ({ dispatch }) => next => action => {
   // action not in namespace? abort!
@@ -23,6 +24,10 @@ const ClaimsMiddleware = ({ dispatch }) => next => action => {
     dispatch(
       farce.push(`${routes.search.path}/${action.payload.createClaim.subject}`)
     )
+  }
+
+  if (claims.READ_CLAIMS === action.type && hasAsyncActionSucceeded(action)) {
+    dispatch(profile.addProfileClaims(action.payload.claim))
   }
 
   return next(action)

--- a/app/core/reducers/index.js
+++ b/app/core/reducers/index.js
@@ -3,6 +3,7 @@ import { combineReducers } from 'redux-immutablejs'
 
 import * as Claims from 'domains/claims'
 import * as Identity from 'domains/identity'
+import * as Profile from 'domains/profile'
 import * as Session from 'domains/session'
 import * as UI from 'domains/ui'
 
@@ -10,6 +11,7 @@ export default combineReducers({
   found: foundReducer,
   [Claims.name]: Claims.reducer,
   [Identity.name]: Identity.reducer,
+  [Profile.name]: Profile.reducer,
   [Session.name]: Session.reducer,
   [UI.name]: UI.reducer,
 })

--- a/app/core/services/meta-claims.js
+++ b/app/core/services/meta-claims.js
@@ -1,5 +1,29 @@
 import { CREDENTIALS, META_CLAIMS_SERVICES, NODE_ENV } from 'core/constants'
-import { Fetch } from 'core/services'
+import { Fetch, Swarm } from 'core/services'
+import { metaId } from 'core/util'
+
+/**
+ * Fetch profile claims data from Swarm
+ *
+ * @param  {Array}  claims Set of profile claims
+ * @return {Object}        Resolved profile claims data
+ */
+export const fetchProfileClaims = claims => {
+  // filter profile claims from the claims set
+  const profileClaims = metaId.getProfileClaimsFromMetaIdentityClaims(claims)
+
+  // fetch profile claim data from Swarm using the raw claim hash
+  const promises = profileClaims.map(({ claim }) => Swarm.download(claim))
+
+  // return profile claims data indexed by Swarm hash
+  return Promise.all(promises).then(values => {
+    return values
+      .map((v, i) => ({
+        [`${profileClaims[i].claim}`]: new TextDecoder('utf-8').decode(v),
+      }))
+      .reduce((o, v) => Object.assign({}, o, v), {})
+  })
+}
 
 /**
  * Verify a META Claim with a META Claims Service

--- a/app/core/util/meta-id.js
+++ b/app/core/util/meta-id.js
@@ -131,6 +131,16 @@ export const createVerifiedIdentityClaimObject = (
 }
 
 /**
+ * Filter all profile claims from a set of META Identity Claim objects
+ *
+ * @param  {Array} claims Set of META Identity Claim objects
+ * @return {Array}        Filtered profile claims
+ */
+export const getProfileClaimsFromMetaIdentityClaims = claims => {
+  return claims.filter(claim => isProfileClaim(claim))
+}
+
+/**
  * Truncate a META-ID owner
  *
  * @example 0x2f138CC4179cA8FF8504cbE74e52f321F855B541 => 0x2f1...541
@@ -150,3 +160,13 @@ export const getTruncatedMetaIdOwner = (owner = '') => {
  */
 export const getUsernameFromName = commonName =>
   `${slugify(commonName.toLowerCase())}.${META_ID_USERNAME_SUFFIX}`
+
+/**
+ * Check whether a claim is a profile claim
+ *
+ * @param  {Object}  claim META Identity Claim object
+ * @return {Boolean}       Profile claim boolean
+ */
+export const isProfileClaim = claim => {
+  return claim.property.startsWith(`${PROFILE_CLAIM_PREFIX}.`)
+}

--- a/app/core/util/meta-id.js
+++ b/app/core/util/meta-id.js
@@ -1,7 +1,7 @@
 import { bufferToHex, ecsign, sha3, toBuffer, toRpcSig } from 'ethereumjs-util'
 import slugify from 'slugify'
 
-import { META_ID_USERNAME_SUFFIX } from 'core/constants'
+import { META_ID_USERNAME_SUFFIX, PROFILE_CLAIM_PREFIX } from 'core/constants'
 import { accounts } from 'core/util'
 
 /**
@@ -75,7 +75,7 @@ export const createProfileMetaIdentityClaim = (
     {
       id: issuer.id,
       privateKey: issuer.privateKey,
-      property: `profile.${subProperty}`,
+      property: `${PROFILE_CLAIM_PREFIX}.${subProperty}`,
     },
     issuer.id
   )

--- a/app/domains/profile/actionTypes.js
+++ b/app/domains/profile/actionTypes.js
@@ -1,0 +1,3 @@
+import { name } from './constants'
+
+export const ADD_PROFILE_CLAIMS = `${name}/ADD_PROFILE_CLAIMS`

--- a/app/domains/profile/actions.js
+++ b/app/domains/profile/actions.js
@@ -1,0 +1,13 @@
+import * as actions from './actionTypes'
+import { MetaClaims } from 'core/services'
+
+/**
+ * Add profile claims data fetched from Swarm
+ *
+ * @param  {Array} claims Set of META Identity Claim objects
+ * @return {Object}       Flux Standard Action
+ */
+export const addProfileClaims = claims => ({
+  type: actions.ADD_PROFILE_CLAIMS,
+  promise: MetaClaims.fetchProfileClaims(claims),
+})

--- a/app/domains/profile/constants.js
+++ b/app/domains/profile/constants.js
@@ -1,0 +1,1 @@
+export const name = 'profile'

--- a/app/domains/profile/index.js
+++ b/app/domains/profile/index.js
@@ -1,0 +1,7 @@
+import * as actions from './actions'
+import * as actionTypes from './actionTypes'
+import { name } from './constants'
+import reducer from './reducer'
+import selectors from './selectors'
+
+export { actions, actionTypes, name, reducer, selectors }

--- a/app/domains/profile/reducer.js
+++ b/app/domains/profile/reducer.js
@@ -1,0 +1,10 @@
+import Immutable from 'immutable'
+import { createReducer } from 'redux-immutablejs'
+
+import * as actions from './actionTypes'
+
+export const initialState = Immutable.fromJS({})
+
+export default createReducer(initialState, {
+  [actions.ADD_PROFILE_CLAIMS]: (state, action) => state.merge(action.payload),
+})

--- a/app/domains/profile/selectors.js
+++ b/app/domains/profile/selectors.js
@@ -1,0 +1,13 @@
+import { name } from './constants'
+
+/**
+ * Select the entire domain from the store by `name`
+ *
+ * @param  {Object} state Redux store
+ * @return {Object}       Domain state
+ */
+const getAll = state => state.get(name)
+
+export default {
+  profile: getAll,
+}


### PR DESCRIPTION
Closes #71 

- Middleware to intercept a 'read claims' action and dispatch the profile claims action
- Utility methods to filter profile claims from a set of claims about an identity
- Service to resolve profile claims data from a claimed Swarm hash
- Action/reducer to add resolved profile claims to the Redux store